### PR TITLE
fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,5 +46,7 @@ jobs:
           subject-path: "dist/*.zip"
 
       - name: upload assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "$GITHUB_REF_NAME" -- dist/*.zip


### PR DESCRIPTION
forgot that `gh` CLI requires `GH_TOKEN` instead of the built-in `GITHUB_TOKEN`...
