### PR TITLE
Better performance by caching strings more

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,10 +8,8 @@ uv = "latest"
 protoc = "33.4"
 protoc-gen-go = "1.36.11"
 "aqua:tinygo-org/tinygo" = "0.40.1"
-
-[tools."github:firefly-zero/firefly-cli"]
-version = "0.15.7"
-rename_exe = "ff"
+"github:firefly-zero/firefly-cli"= { version = "0.15.8", rename_exe = "ff" }
+"github:firefly-zero/firefly-emulator" = "0.9.8"
 
 [tasks."install:tools"]
 description = "Install protoc plugins"

--- a/pkg/game/ui.go
+++ b/pkg/game/ui.go
@@ -1,7 +1,6 @@
 package game
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/applejag/epic-wizard-firefly-gladiators/assets"
@@ -10,7 +9,12 @@ import (
 	"github.com/firefly-zero/firefly-go/firefly"
 )
 
-type UI struct{}
+type UI struct {
+	cachedMoneyValue     int
+	cachedMoneyText      string
+	cachedFirefliesValue int
+	cachedFirefliesText  string
+}
 
 func (u *UI) Render() {
 	if len(state.Game.Fireflies) == 0 {
@@ -18,15 +22,31 @@ func (u *UI) Render() {
 		return
 	}
 	assets.CashBanner.Draw(firefly.P(2, 2))
+
+	moneyText := u.cachedMoneyText
+	money := min(state.Game.Money, 9999)
+	if moneyText == "" || money != u.cachedMoneyValue {
+		moneyText = formatPaddedInt(money, 4)
+		u.cachedMoneyText = moneyText
+		u.cachedMoneyValue = money
+	}
+	firefliesText := u.cachedFirefliesText
+	fireflies := min(len(state.Game.Fireflies), 99)
+	if firefliesText == "" || fireflies != u.cachedFirefliesValue {
+		firefliesText = formatPaddedInt(fireflies, 2)
+		u.cachedFirefliesText = firefliesText
+		u.cachedFirefliesValue = fireflies
+	}
+
 	drawRightAlignedWithColoredZeros(
 		assets.FontEG_6x9,
-		fmt.Sprintf("%04d", min(state.Game.Money, 9999)),
+		moneyText,
 		firefly.P(29, 12),
 		firefly.ColorLightGray,
 		firefly.ColorDarkGray)
 	drawRightAlignedWithColoredZeros(
 		assets.FontEG_6x9,
-		fmt.Sprintf("%02d", min(len(state.Game.Fireflies), 99)),
+		firefliesText,
 		firefly.P(59, 12),
 		firefly.ColorLightGray,
 		firefly.ColorDarkGray)
@@ -39,4 +59,18 @@ func drawRightAlignedWithColoredZeros(font firefly.Font, text string, right fire
 	zeros := text[:len(text)-len(withoutZeros)]
 	font.Draw(zeros, left, zeroColor)
 	font.Draw(withoutZeros, left.Add(firefly.P(font.LineWidth(zeros), 0)), textColor)
+}
+
+func formatPaddedInt(value, width int) string {
+	buf := make([]byte, width)
+	for i := range buf {
+		buf[i] = '0'
+	}
+	index := len(buf) - 1
+	for value > 0 && index >= 0 {
+		buf[index] = '0' + byte(value%10)
+		value /= 10
+		index -= 1
+	}
+	return string(buf)
 }

--- a/pkg/game/ui_test.go
+++ b/pkg/game/ui_test.go
@@ -1,0 +1,47 @@
+package game
+
+import "testing"
+
+func TestFormatPaddedInt(t *testing.T) {
+	tests := []struct {
+		name  string
+		num   int
+		width int
+		want  string
+	}{
+		{
+			name:  "zero width",
+			num:   1,
+			width: 0,
+			want:  "",
+		},
+		{
+			name:  "width shorter than value",
+			num:   99,
+			width: 1,
+			want:  "9",
+		},
+		{
+			name:  "just the correct width",
+			num:   99,
+			width: 2,
+			want:  "99",
+		},
+		{
+			name:  "shorter than width",
+			num:   99,
+			width: 4,
+			want:  "0099",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := formatPaddedInt(test.num, test.width)
+			if got != test.want {
+				t.Errorf("wrong result from formatPaddedInt(%d, %d)\nwant: %q\ngot:  %q",
+					test.num, test.width, test.want, got)
+			}
+		})
+	}
+}

--- a/pkg/scenes/field/fireflymodal.go
+++ b/pkg/scenes/field/fireflymodal.go
@@ -19,7 +19,7 @@ const (
 	ModalClosed ModalState = iota
 	ModalStats
 	ModalHats
-	ModalTournament
+	ModalRacing
 )
 
 type FireflyModal struct {
@@ -43,10 +43,20 @@ func (m *FireflyModal) IsClosing() bool {
 
 func (m *FireflyModal) Open(firefly *Firefly) {
 	m.scrollOpenAnim.Play()
-	m.state = ModalStats
-	m.statsPage.focused = StatsNone
-	m.racingPage.focused = RacingNone
 	m.firefly = firefly
+	m.OpenPage(ModalStats)
+}
+
+func (m *FireflyModal) OpenPage(target ModalState) {
+	m.state = target
+	switch target {
+	case ModalStats:
+		m.statsPage.OnOpen()
+		m.statsPage.focused = StatsNone
+	case ModalRacing:
+		m.racingPage.OnOpen()
+		m.racingPage.focused = RacingNone
+	}
 }
 
 func (m *FireflyModal) Close() {
@@ -92,7 +102,7 @@ func (m *FireflyModal) Update() {
 	switch m.state {
 	case ModalStats:
 		m.statsPage.Update(m)
-	case ModalTournament:
+	case ModalRacing:
 		m.racingPage.Update(m)
 	}
 
@@ -102,7 +112,7 @@ func (m *FireflyModal) Update() {
 			if m.state == ModalStats {
 				m.Close()
 			} else {
-				m.state = ModalStats
+				m.OpenPage(ModalStats)
 			}
 		}
 	}
@@ -128,7 +138,7 @@ func (m *FireflyModal) renderScroll(point firefly.Point) {
 	switch m.state {
 	case ModalStats:
 		m.statsPage.Render(innerScrollPoint, m.firefly.id)
-	case ModalTournament:
+	case ModalRacing:
 		m.racingPage.Render(innerScrollPoint)
 	}
 }

--- a/pkg/scenes/field/fireflymodal_racing.go
+++ b/pkg/scenes/field/fireflymodal_racing.go
@@ -25,6 +25,9 @@ func (p *RacingPage) Boot() {
 	p.tournamentBtn.Font = assets.FontEG_6x9
 }
 
+func (p *RacingPage) OnOpen() {
+}
+
 func (p *RacingPage) Update(modal *FireflyModal) {
 	p.tournamentAnim.Update()
 	p.trainingAnim.Update()

--- a/pkg/scenes/field/fireflymodal_stats.go
+++ b/pkg/scenes/field/fireflymodal_stats.go
@@ -15,6 +15,10 @@ type StatsPage struct {
 	giveVitaminsBtn   Button
 	playTournamentBtn Button
 	focused           StatsButton
+
+	cachedFireflyNameText string
+	cachedSpeedText       string
+	cachedNimblenessText  string
 }
 
 func (p *StatsPage) Boot() {
@@ -23,6 +27,12 @@ func (p *StatsPage) Boot() {
 	p.giveVitaminsBtn = NewButton("GIVE VITAMINS")
 	p.giveVitaminsBtn.Disabled = true
 	p.playTournamentBtn = NewButton("RACING")
+}
+
+func (p *StatsPage) OnOpen() {
+	p.cachedFireflyNameText = ""
+	p.cachedSpeedText = ""
+	p.cachedNimblenessText = ""
 }
 
 func (p *StatsPage) Update(modal *FireflyModal) {
@@ -60,7 +70,7 @@ func (p *StatsPage) handleInputButtons(justPressed firefly.Buttons, modal *Firef
 			// Shake to signify that the button doesn't work
 			p.giveVitaminsBtn.Shake()
 		case StatsRacing:
-			modal.state = ModalTournament
+			modal.OpenPage(ModalRacing)
 		}
 	}
 }
@@ -72,11 +82,26 @@ func (p *StatsPage) Render(innerScrollPoint firefly.Point, fireflyID int) {
 	}
 	data := state.Game.Fireflies[dataIndex]
 
-	text := util.WordWrap(
-		data.Name.String(),
-		scrollInnerWidth,
-		assets.FontEG_6x9.CharWidth(),
-	)
+	text := p.cachedFireflyNameText
+	if text == "" {
+		text = util.WordWrap(
+			data.Name.String(),
+			scrollInnerWidth,
+			assets.FontEG_6x9.CharWidth(),
+		)
+		p.cachedFireflyNameText = text
+	}
+
+	speedText := p.cachedSpeedText
+	if speedText == "" {
+		speedText = strconv.Itoa(data.Speed)
+		p.cachedSpeedText = speedText
+	}
+	nimblenessText := p.cachedNimblenessText
+	if nimblenessText == "" {
+		nimblenessText = strconv.Itoa(data.Nimbleness)
+		p.cachedNimblenessText = speedText
+	}
 
 	charHeight := assets.FontEG_6x9.CharHeight()
 
@@ -85,11 +110,11 @@ func (p *StatsPage) Render(innerScrollPoint firefly.Point, fireflyID int) {
 	textHeight := charHeight * (strings.Count(text, "\n") + 1)
 
 	speedPoint := textPos.Add(firefly.P(2, textHeight))
-	assets.FontEG_6x9.Draw(strconv.Itoa(data.Speed), speedPoint, firefly.ColorBlack)
+	assets.FontEG_6x9.Draw(speedText, speedPoint, firefly.ColorBlack)
 	assets.FontPico8_4x6.Draw("SPEED", speedPoint.Add(firefly.P(0, charHeight)), firefly.ColorGray)
 
 	nimblenessPoint := speedPoint.Add(firefly.P(32, 0))
-	assets.FontEG_6x9.Draw(strconv.Itoa(data.Nimbleness), nimblenessPoint, firefly.ColorBlack)
+	assets.FontEG_6x9.Draw(nimblenessText, nimblenessPoint, firefly.ColorBlack)
 	assets.FontPico8_4x6.Draw("NIMBLE", nimblenessPoint.Add(firefly.P(0, charHeight)), firefly.ColorGray)
 
 	rectPoint := textPos.Add(firefly.P(64, textHeight+4-charHeight))


### PR DESCRIPTION
Performance is allegedly bad on the actual Firefly Zero device.

It's hard to debug, but one thing we're doing wrong is that we're creating a lot of strings in every update. The GC can be a big culprit.

Let's cache the strings instead so we don't have to calculate the word-wrapping and string allocation on each frame.

Closes #11
