### PR TITLE
Update SDK

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/applejag/epic-wizard-firefly-gladiators
 go 1.25.5
 
 require (
-	github.com/applejag/firefly-go-math v0.2.0
-	github.com/firefly-zero/firefly-go v0.11.0
+	github.com/applejag/firefly-go-math v0.2.1
+	github.com/firefly-zero/firefly-go v0.12.0
 	github.com/orsinium-labs/tinymath v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/applejag/firefly-go-math v0.2.0 h1:IiDXTbHpLDU8LR8LP3RKGpyUA59mQp2HwAdkDyLLask=
-github.com/applejag/firefly-go-math v0.2.0/go.mod h1:XbmMPAO9vDIYvwAJIPlY6HE0m1RZ3tXgn3GP9agFXos=
-github.com/firefly-zero/firefly-go v0.11.0 h1:+Y5EE0sXxjylZo9H3U3+VpPU1bCXdq0q7xnrpn207pg=
-github.com/firefly-zero/firefly-go v0.11.0/go.mod h1:osit9/kxcqSUBVozePb7LNzOHy3FQ7ii1Z0mL82pWu0=
+github.com/applejag/firefly-go-math v0.2.1 h1:uUswt1hBG96F/rTcS/DZ/9/kPze0SEmQIsL95GBjOWQ=
+github.com/applejag/firefly-go-math v0.2.1/go.mod h1:mjY0WcVMrmkPGtsGlczdPYdP9hI9mU+z7hmsBPktyXg=
+github.com/firefly-zero/firefly-go v0.12.0 h1:yNFB33cgYZIPWKZTDNrjDDCw5tqx+CzMGms+daXoz88=
+github.com/firefly-zero/firefly-go v0.12.0/go.mod h1:osit9/kxcqSUBVozePb7LNzOHy3FQ7ii1Z0mL82pWu0=
 github.com/orsinium-labs/tinymath v1.1.0 h1:KomdsyLHB7vE3f1nRAJF2dyf1m/gnM2HxfTeV1vS5UA=
 github.com/orsinium-labs/tinymath v1.1.0/go.mod h1:WPXX6ei3KSXG7JfA03a+ekCYaY9SWN4I+JRl2p6ck+A=

--- a/pkg/state/input.go
+++ b/pkg/state/input.go
@@ -17,7 +17,7 @@ type InputState struct {
 }
 
 func (i *InputState) Boot() {
-	i.Me = firefly.GetMe()
+	i.Me = firefly.Combined
 }
 
 func (i *InputState) Update() {


### PR DESCRIPTION
The upcoming (hopefully this weekend) Firefly Zero release drops support for the old image format. To make sure the aussie froggy still works when installed from the catalog, you need to re-build it with the latest CLI version and publish it.

Also closes #30